### PR TITLE
csvWriter: generator correctness & robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ go.work.sum
 .cache
 .trae
 /data/
+*.tar.gz

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Currently, this tool supports the following data types:
 -	int: The value range is consistent with int32
 -	bigint: The value range is consistent with int64
 -	boolean: The value is `0` or `1`
--	decimal: The total number of decimal digits is `27`, The number of digits after the decimal point is `9`
+-	decimal: Format is `<integer>.<fraction>`, integer part is in `[0, 1e18)`, fraction has `10` digits (zero-padded)
 -	string: The character scope is [a-zA-Z0-9]
 -	timestamp: Time from `1971-1-1 00:00:00` to now
 -	json: The marshal result of struct `UserInfo`

--- a/file_task.go
+++ b/file_task.go
@@ -1,12 +1,10 @@
 package main
 
 import (
+	"encoding/base64"
 	"log"
 	"math/rand"
-	"strconv"
 	"strings"
-
-	"github.com/google/uuid"
 )
 
 func (t *Task) hasMoreRows() bool {
@@ -18,56 +16,35 @@ func (t *Task) nextRow(rng *rand.Rand, out *strings.Builder) {
 		if i > 0 {
 			out.WriteByte(byte(fieldDelimiter))
 		}
-		switch col.Type {
-		case STRING:
-			col.genStr(rng, out)
-		case INT, BIGINT:
-			col.genInt(rng, t.curr, out)
-		default:
-			log.Printf("Unsupported type: %s", col.Type)
+
+		if *base64Encode {
+			encoder := base64.NewEncoder(base64.StdEncoding, out)
+			if err := col.writeRawValue(rng, t.curr, t.timestampEndUnix, encoder); err != nil {
+				_ = encoder.Close()
+				log.Fatal(err)
+			}
+			if err := encoder.Close(); err != nil {
+				log.Fatal(err)
+			}
+			continue
+		}
+
+		if col.Type == JSON {
+			raw, err := col.rawValueString(rng, t.curr, t.timestampEndUnix)
+			if err != nil {
+				log.Fatal(err)
+			}
+			if raw == nullVal {
+				out.WriteString(nullVal)
+			} else {
+				out.WriteString(escapeJSONString(raw))
+			}
+			continue
+		}
+
+		if err := col.writeRawValue(rng, t.curr, t.timestampEndUnix, out); err != nil {
+			log.Fatal(err)
 		}
 	}
 	t.curr++
-}
-
-func (c *Column) genInt(rng *rand.Rand, rowID int, out *strings.Builder) {
-	if c.canThisValNull(rng) {
-		out.WriteString(nullVal)
-	} else if c.IsPK || c.IsUnique {
-		out.WriteString(strconv.Itoa(rowID))
-	} else if c.StdDev != 0 { // normal distribution int
-		out.WriteString(generateNormalDistributeInt32(rng, c.StdDev, c.Mean))
-	} else {
-		out.WriteString(generateUniformDistributeInt32(rng))
-	}
-}
-
-func (c *Column) genStr(rng *rand.Rand, out *strings.Builder) {
-	if c.canThisValNull(rng) {
-		out.WriteString(nullVal)
-	} else if c.IsPK || c.IsUnique {
-		out.WriteString(uuid.New().String())
-		c.genRandStr(rng, c.MinLen-uuidLen, c.MaxLen-uuidLen, out)
-	} else {
-		c.genRandStr(rng, c.MinLen, c.MaxLen, out)
-	}
-}
-
-func (c *Column) genRandStr(rng *rand.Rand, minLen, maxLen int, out *strings.Builder) {
-	length := minLen
-	if maxLen > minLen {
-		length += rng.Intn(maxLen - minLen + 1)
-	}
-	out.Grow(length)
-
-	randSlice := make([]byte, length)
-	_, err := rng.Read(randSlice)
-	if err != nil {
-		panic(err)
-	}
-
-	for i := 0; i < length; i++ {
-		pick := int(randSlice[i]) % len(randomChars)
-		out.WriteByte(randomChars[pick])
-	}
 }

--- a/file_task_test.go
+++ b/file_task_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/csv"
+	"encoding/json"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+func TestTaskNextRow_JSONIsSingleField(t *testing.T) {
+	originalBase64 := *base64Encode
+	*base64Encode = false
+	t.Cleanup(func() { *base64Encode = originalBase64 })
+
+	task := Task{
+		curr: 0,
+		end:  1,
+		cols: []*Column{{Type: JSON}},
+	}
+	rng := rand.New(rand.NewSource(1))
+	sb := &strings.Builder{}
+	task.nextRow(rng, sb)
+
+	reader := csv.NewReader(strings.NewReader(sb.String()))
+	reader.Comma = fieldDelimiter
+	record, err := reader.Read()
+	if err != nil {
+		t.Fatalf("read csv: %v", err)
+	}
+	if len(record) != 1 {
+		t.Fatalf("expected 1 field, got %d: %q", len(record), record)
+	}
+
+	var decoded UserInfo
+	if err := json.Unmarshal([]byte(record[0]), &decoded); err != nil {
+		t.Fatalf("field is not valid json: %v; value=%q", err, record[0])
+	}
+}
+
+func TestTaskNextRow_JSONNull_NotQuoted(t *testing.T) {
+	originalBase64 := *base64Encode
+	*base64Encode = false
+	t.Cleanup(func() { *base64Encode = originalBase64 })
+
+	task := Task{
+		curr: 0,
+		end:  1,
+		cols: []*Column{{Type: JSON, NullRatio: 100}},
+	}
+	rng := rand.New(rand.NewSource(1))
+	sb := &strings.Builder{}
+	task.nextRow(rng, sb)
+
+	reader := csv.NewReader(strings.NewReader(sb.String()))
+	reader.Comma = fieldDelimiter
+	record, err := reader.Read()
+	if err != nil {
+		t.Fatalf("read csv: %v", err)
+	}
+	if len(record) != 1 {
+		t.Fatalf("expected 1 field, got %d: %q", len(record), record)
+	}
+	if record[0] != nullVal {
+		t.Fatalf("expected null %q, got %q", nullVal, record[0])
+	}
+}
+
+func TestTaskNextRow_JSONBase64DecodesToJSON(t *testing.T) {
+	originalBase64 := *base64Encode
+	*base64Encode = true
+	t.Cleanup(func() { *base64Encode = originalBase64 })
+
+	task := Task{
+		curr: 0,
+		end:  1,
+		cols: []*Column{{Type: JSON}},
+	}
+	rng := rand.New(rand.NewSource(2))
+	sb := &strings.Builder{}
+	task.nextRow(rng, sb)
+
+	reader := csv.NewReader(strings.NewReader(sb.String()))
+	reader.Comma = fieldDelimiter
+	record, err := reader.Read()
+	if err != nil {
+		t.Fatalf("read csv: %v", err)
+	}
+	if len(record) != 1 {
+		t.Fatalf("expected 1 field, got %d: %q", len(record), record)
+	}
+
+	decodedFieldBytes, err := base64.StdEncoding.DecodeString(record[0])
+	if err != nil {
+		t.Fatalf("not base64: %v; value=%q", err, record[0])
+	}
+
+	var decoded UserInfo
+	if err := json.Unmarshal(decodedFieldBytes, &decoded); err != nil {
+		t.Fatalf("decoded field is not valid json: %v; value=%q", err, string(decodedFieldBytes))
+	}
+}
+
+func TestTaskNextRow_AllSupportedTypes_ParseableAsCSV(t *testing.T) {
+	originalBase64 := *base64Encode
+	*base64Encode = false
+	t.Cleanup(func() { *base64Encode = originalBase64 })
+
+	task := Task{
+		curr: 0,
+		end:  1,
+		cols: []*Column{
+			{Type: STRING, MinLen: 8, MaxLen: 12},
+			{Type: BOOLEAN},
+			{Type: INT},
+			{Type: BIGINT, Order: totalOrdered},
+			{Type: DECIMAL},
+			{Type: TIMESTAMP},
+			{Type: JSON},
+		},
+	}
+	rng := rand.New(rand.NewSource(3))
+	sb := &strings.Builder{}
+	task.nextRow(rng, sb)
+
+	reader := csv.NewReader(strings.NewReader(sb.String()))
+	reader.Comma = fieldDelimiter
+	record, err := reader.Read()
+	if err != nil {
+		t.Fatalf("read csv: %v", err)
+	}
+	if len(record) != 7 {
+		t.Fatalf("expected 7 fields, got %d: %q", len(record), record)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -859,6 +859,9 @@ func main() {
 		return
 	}
 	if *useProcessor {
+		if *localPath != "" {
+			log.Fatal("useProcessor mode does not support localPath; unset localPath or disable useProcessor")
+		}
 		genWithTaskProcessor()
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -779,24 +779,9 @@ func generateData() {
 
 	var wgWriter sync.WaitGroup
 	// Start writer workers
-	op := objstore.BackendOptions{S3: s3like.S3BackendOptions{
-		Region:          *s3Region,
-		AccessKey:       *s3AccessKey,
-		SecretAccessKey: *s3SecretKey,
-		Provider:        *s3Provider,
-		Endpoint:        *s3Endpoint,
-		RoleARN:         *s3RoleARN,
-	}}
-	s, err := objstore.ParseBackend(*s3Path, &op)
-	if err != nil {
-		panic(err)
-	}
 	var store storeapi.Storage
 	if *localPath == "" {
-		store, err = objstore.NewWithDefaultOpt(context.Background(), s)
-		if err != nil {
-			panic(err)
-		}
+		store = createExternalStorage()
 	}
 	for i := 0; i < *writerNum; i++ {
 		wgWriter.Add(1)

--- a/main.go
+++ b/main.go
@@ -680,7 +680,7 @@ func writerWorker(resultsCh <-chan Result, store storeapi.Storage, workerID int,
 		for attempt := 1; attempt <= maxRetries; attempt++ {
 			startTime := time.Now()
 			if *localPath != "" {
-				err = writeCSVToLocalDisk(*localPath+fileName, result.values)
+				err = writeCSVToLocalDisk(filepath.Join(*localPath, fileName), result.values)
 				if err != nil {
 					log.Fatal("Error writing output file:", err)
 				}

--- a/main.go
+++ b/main.go
@@ -182,7 +182,7 @@ func loadSchemaInfoFromCSV(filename string) []*Column {
 		if columns[i].Mean, err = strconv.ParseFloat(colInfo[7], 64); len(colInfo[7]) != 0 && err != nil {
 			panic(err)
 		}
-		if columns[i].StdDev, err = strconv.ParseFloat(colInfo[8], 64); len(colInfo[7]) != 0 && err != nil {
+		if columns[i].StdDev, err = strconv.ParseFloat(colInfo[8], 64); len(colInfo[8]) != 0 && err != nil {
 			panic(err)
 		}
 		checkColumnInfoLegality(columns[i])

--- a/main.go
+++ b/main.go
@@ -796,8 +796,8 @@ func generateData() {
 	log.Printf("Total tasks: %d, each task generates at most %d rows", taskCount, *rowNumPerFile)
 
 	// Create tasks and results channels
-	tasksCh := make(chan Task, *generatorNum+1)
-	resultsCh := make(chan Result, *writerNum+1)
+	tasksCh := make(chan Task, 1)
+	resultsCh := make(chan Result, 1)
 
 	// Create a sync.Pool for reusing [][]string slices, initial capacity equals number of columns
 	pool := &sync.Pool{

--- a/main.go
+++ b/main.go
@@ -458,6 +458,7 @@ func createExternalStorage() storeapi.Storage {
 		SecretAccessKey: *s3SecretKey,
 		Provider:        *s3Provider,
 		Endpoint:        *s3Endpoint,
+		RoleARN:         *s3RoleARN,
 	}}
 	s, err := objstore.ParseBackend(*s3Path, &op)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -528,9 +528,13 @@ func glanceFiles(fileName string) {
 	if err != nil {
 		panic(fmt.Errorf("failed to open file %s: %v", fileName, err))
 	}
+	defer r.Close()
 	b := make([]byte, 1*units.MiB)
-	r.Read(b)
-	fmt.Println(string(b))
+	n, err := r.Read(b)
+	if err != nil && err != io.EOF {
+		panic(fmt.Errorf("failed to read file %s: %v", fileName, err))
+	}
+	fmt.Println(string(b[:n]))
 }
 
 func fetchFileFromS3(fileName string) {

--- a/processor.go
+++ b/processor.go
@@ -59,7 +59,14 @@ func genWithTaskProcessor() {
 	processors := make([]*processor, 0, *generatorNum)
 	var doneProcessors atomic.Int32
 	allProcessorDone := make(chan struct{})
-	tasksCh := make(chan Task, taskCount)
+	taskQueueSize := *generatorNum * 2
+	if taskQueueSize < 1 {
+		taskQueueSize = 1
+	}
+	if taskQueueSize > 1024 {
+		taskQueueSize = 1024
+	}
+	tasksCh := make(chan Task, taskQueueSize)
 	for i := 0; i < *generatorNum; i++ {
 		rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 		p := &processor{

--- a/processor.go
+++ b/processor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/go-units"
 	"github.com/pingcap/tidb/pkg/objstore"
 	"github.com/pingcap/tidb/pkg/objstore/objectio"
+	"github.com/pingcap/tidb/pkg/objstore/s3like"
 	"github.com/pingcap/tidb/pkg/objstore/storeapi"
 	"github.com/pingcap/tidb/pkg/util"
 )
@@ -35,11 +36,16 @@ func genWithTaskProcessor() {
 	taskCount := (rowCount + *rowNumPerFile - 1) / *rowNumPerFile
 	log.Printf("Total tasks: %d, each task generates at most %d rows", taskCount, *rowNumPerFile)
 
-	u, err := objstore.ParseRawURL(*s3Path)
-	if err != nil {
-		panic(err)
-	}
-	s, err := objstore.ParseBackendFromURL(u, nil)
+	// Keep consistent with the non-processor path: respect the CLI S3 flags (endpoint/provider/aksk/role/etc).
+	op := objstore.BackendOptions{S3: s3like.S3BackendOptions{
+		Region:          *s3Region,
+		AccessKey:       *s3AccessKey,
+		SecretAccessKey: *s3SecretKey,
+		Provider:        *s3Provider,
+		Endpoint:        *s3Endpoint,
+		RoleARN:         *s3RoleARN,
+	}}
+	s, err := objstore.ParseBackend(*s3Path, &op)
 	if err != nil {
 		panic(err)
 	}

--- a/processor.go
+++ b/processor.go
@@ -179,6 +179,7 @@ func (p *processor) generate(ctx context.Context, tasksCh <-chan Task) error {
 		if !ok {
 			break
 		}
+		task.timestampEndUnix = time.Now().Unix()
 		for task.hasMoreRows() {
 			sb := &strings.Builder{}
 			for sb.Len() < 4*units.MiB && task.hasMoreRows() {

--- a/table_info.csv
+++ b/table_info.csv
@@ -1,10 +1,24 @@
 name,type,is_pk,is_unique,min_len,max_len,null_ratio,mean,std_dev,order
-a,string,,1,40,40,,,,
-b,boolean,,,,,,,,
-c,int,,,,,,,,
-d,bigint,,,,,,,,
-f,decimal,,,,,,,,
-g,timestamp,,,,,,,,
-h,json,,,,,,,,
-a,string,,1,400000,400000,,,,
-c,int,,,,,,,,total random
+pk_int,int,1,,,,,,,
+uk_int_nullable,int,,1,,,20,,,
+int_uniform_nullable,int,,,,,5,,,
+int_normal,int,,,,,0,100,15,
+pk_bigint,bigint,1,,,,,,,
+uk_bigint_nullable,bigint,,1,,,20,,,
+bigint_random_nullable,bigint,,,,,5,,,
+bigint_total_ordered,bigint,,,,,0,,,total ordered
+bigint_partial_ordered_nullable,bigint,,,,,10,,,partial ordered
+bigint_total_random_nullable,bigint,,,,,10,,,total random
+bool_no_null,boolean,,,,,0,,,
+bool_all_null,boolean,,,,,100,,,
+dec_no_null,decimal,,,,,0,,,
+dec_nullable,decimal,,,,,30,,,
+str_pk_uuid,string,1,,36,36,,,,
+str_uk_uuid_nullable,string,,1,36,36,30,,,
+str_uk_varlen,string,,1,40,80,0,,,
+str_varlen_nullable,string,,,1,32,10,,,
+str_empty,string,,,0,0,0,,,
+ts_no_null,timestamp,,,,,0,,,
+ts_nullable,timestamp,,,,,30,,,
+json_no_null,json,,,,,0,,,
+json_nullable,json,,,,,30,,,

--- a/value_gen.go
+++ b/value_gen.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"math/rand"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var timestampStartUnix = time.Date(1971, 1, 1, 0, 0, 0, 0, time.UTC).Unix()
+
+func (c *Column) rawValueString(rng *rand.Rand, rowID int, timestampEndUnix int64) (string, error) {
+	var builder strings.Builder
+	if err := c.writeRawValue(rng, rowID, timestampEndUnix, &builder); err != nil {
+		return "", err
+	}
+	return builder.String(), nil
+}
+
+func (c *Column) writeRawValue(rng *rand.Rand, rowID int, timestampEndUnix int64, w io.Writer) error {
+	if c.canThisValNull(rng) {
+		_, err := io.WriteString(w, nullVal)
+		return err
+	}
+
+	switch c.Type {
+	case STRING:
+		if c.IsPK || c.IsUnique {
+			if _, err := io.WriteString(w, uuid.New().String()); err != nil {
+				return err
+			}
+			return writeRandomChars(rng, c.MinLen-uuidLen, c.MaxLen-uuidLen, w)
+		}
+		return writeRandomChars(rng, c.MinLen, c.MaxLen, w)
+	case BOOLEAN:
+		one := byte('0' + rng.Intn(2))
+		_, err := w.Write([]byte{one})
+		return err
+	case INT:
+		if c.IsPK || c.IsUnique {
+			_, err := io.WriteString(w, strconv.Itoa(rowID))
+			return err
+		}
+		if c.StdDev != 0 {
+			_, err := io.WriteString(w, generateNormalDistributeInt32(rng, c.StdDev, c.Mean))
+			return err
+		}
+		_, err := io.WriteString(w, generateUniformDistributeInt32(rng))
+		return err
+	case BIGINT:
+		if len(c.Order) != 0 {
+			value, err := c.bigintByOrderString(rng, rowID)
+			if err != nil {
+				return err
+			}
+			_, err = io.WriteString(w, value)
+			return err
+		}
+		if c.IsPK || c.IsUnique {
+			_, err := io.WriteString(w, strconv.Itoa(rowID))
+			return err
+		}
+		n := rng.Int63()
+		if rng.Intn(2) == 0 {
+			n = -n
+		}
+		_, err := io.WriteString(w, strconv.FormatInt(n, 10))
+		return err
+	case DECIMAL:
+		intPart := rng.Int63n(1_000_000_000_000_000_000)
+		decimalPart := rng.Intn(1_000_000_000)
+		_, err := io.WriteString(w, fmt.Sprintf("%d.%010d", intPart, decimalPart))
+		return err
+	case TIMESTAMP:
+		if timestampEndUnix == 0 {
+			timestampEndUnix = time.Now().Unix()
+		}
+		if timestampEndUnix < timestampStartUnix {
+			timestampEndUnix = timestampStartUnix
+		}
+		randomUnix := rng.Int63n(timestampEndUnix-timestampStartUnix+1) + timestampStartUnix
+		_, err := io.WriteString(w, time.Unix(randomUnix, 0).Format("2006-01-02 15:04:05"))
+		return err
+	case JSON:
+		_, err := io.WriteString(w, generateJSON(rng))
+		return err
+	default:
+		return fmt.Errorf("unsupported type: %s", c.Type)
+	}
+}
+
+func (c *Column) bigintByOrderString(rng *rand.Rand, rowID int) (string, error) {
+	switch c.Order {
+	case totalOrdered:
+		return strconv.Itoa(rowID), nil
+	case partialOrdered:
+		if rowID%1000 == 0 {
+			return generateUniqueRandomBigint(rng, rowID), nil
+		}
+		return strconv.Itoa(rowID), nil
+	case totalRandom:
+		return generateUniqueRandomBigint(rng, rowID), nil
+	default:
+		return "", fmt.Errorf("unsupported order: %s", c.Order)
+	}
+}
+
+func writeRandomChars(rng *rand.Rand, minLen, maxLen int, w io.Writer) error {
+	length := minLen
+	if maxLen > minLen {
+		length += rng.Intn(maxLen - minLen + 1)
+	}
+	if length <= 0 {
+		return nil
+	}
+
+	b := make([]byte, length)
+	if _, err := rng.Read(b); err != nil {
+		return err
+	}
+
+	for i := 0; i < length; i++ {
+		pick := int(b[i]) % len(randomChars)
+		b[i] = randomChars[pick]
+	}
+	_, err := w.Write(b)
+	return err
+}


### PR DESCRIPTION
## Summary
- Fix JSON columns in CSV/TSV: properly escape/quote JSON fields so they won’t be split by commas (also works with `-base64Encode`).
- Unify random value generation between normal mode and `-useProcessor` mode via `value_gen.go`, keeping supported types/behavior consistent.
- Improve I/O robustness: handle S3 writer close errors, stream `-fetchFile` to local, harden `-glanceFile`/`-showFile`, batch delete by prefix, and improve local write error handling.
- Processor/pipeline tuning: bound processor task queue, reject `-localPath` in `-useProcessor`, and reduce `tasksCh/resultsCh` buffering to 1 to cap memory spikes.
- Expand `table_info.csv` to cover more edge cases and add tests for JSON CSV parsing.

## Verification
- `go test ./...`
- `go run . ...` and validated generated files by parsing with a standard CSV reader (field count + type parseability).
